### PR TITLE
initial commit with basic functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Pub files.
+build
+packages
+.pub
+pubspec.lock
+
+# Files created by dart2js.
+*.dart.js
+*.dart.precompiled.js
+*.js_
+*.js.deps
+*.js.map
+*.sw?
+
+# Intellij files.
+.idea/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+Copyright 2013, the Dart project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2013, the Dart project authors. All rights reserved.
+Copyright 2015, the Dart project authors. All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:

--- a/lib/src/init_method.dart
+++ b/lib/src/init_method.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 part of static_init;

--- a/lib/src/init_method.dart
+++ b/lib/src/init_method.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+part of static_init;
+
+/// Metadata used to label static or top-level methods that are called
+/// automatically when calling static_init.run(). This class is private because
+/// it shouldn't be used directly in annotations, instead use the `initMethod`
+/// singleton below.
+class _InitMethod implements StaticInitializer<MethodMirror> {
+  const _InitMethod();
+
+  @override
+  initialize(MethodMirror method) {
+    if (!method.isStatic) {
+      throw 'Methods marked with @initMethod should be static, '
+            '${method.simpleName} is not.';
+    }
+    if (method.parameters.any((p) => !p.isOptional)) {
+      throw 'Methods marked with @initMethod should take no arguments, '
+            '${method.simpleName} expects some.';
+    }
+    (method.owner as ObjectMirror).invoke(method.simpleName, const []);
+  }
+}
+
+/// We only ever need one instance of the `_InitMethod` class, this is it.
+const initMethod = const _InitMethod();

--- a/lib/src/static_initializer.dart
+++ b/lib/src/static_initializer.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+part of static_init;
+
+/// Implement this class to create your own initializer.
+///
+/// Hello world example:
+///
+///   class Print implements StaticInitializer<ClassMirror> {
+///     final String message;
+///     const Print(this.message);
+///
+///     @override
+///     initialize(ClassMirror) => print('${t.reflectedType} says `$message`');
+///   }
+///
+///   @Print('hello world!')
+///   class Foo {}
+///
+/// Call run() from your main and this will print 'Foo says `hello world!`'
+///
+abstract class StaticInitializer<T> {
+  dynamic initialize(T target);
+}

--- a/lib/src/static_initializer.dart
+++ b/lib/src/static_initializer.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 part of static_init;

--- a/lib/static_init.dart
+++ b/lib/static_init.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init;
+
+import 'dart:mirrors';
+
+part 'src/init_method.dart';
+part 'src/static_initializer.dart';
+
+/// The root library to start from.
+final _root = currentMirrorSystem().isolate.rootLibrary;
+
+/// Set of all visited annotations, keys are the declarations that were
+/// annotated, values are the annotations that have been processed.
+final _annotationsFound = new Map<DeclarationMirror, Set<InstanceMirror>>();
+
+/// Top level function which crawls the dependency graph and runs initializers.
+void run() {
+  _readLibraryDeclarations(_root);
+}
+
+/// Reads and executes StaticInitializer annotations on this library and all its
+/// dependencies in post-order.
+void _readLibraryDeclarations(
+    LibraryMirror library, [Set<LibraryMirror> librariesSeen]) {
+  if (librariesSeen == null) librariesSeen = new Set<LibraryMirror>();
+  librariesSeen.add(library);
+
+  // First visit all our dependencies.
+  for (var dependency in library.libraryDependencies) {
+    if (librariesSeen.contains(dependency.targetLibrary)) continue;
+    _readLibraryDeclarations(dependency.targetLibrary, librariesSeen);
+  }
+
+  // Then parse all class and method annotations in this library.
+  library
+      .declarations
+      .values
+      .where((d) => d is ClassMirror || d is MethodMirror)
+      .forEach((DeclarationMirror d) => _readAnnotations(d));
+}
+
+void _readAnnotations(DeclarationMirror declaration) {
+  for (var meta in declaration.metadata) {
+    if (meta.reflectee is! StaticInitializer) continue;
+    if (!_annotationsFound.containsKey(declaration)) {
+      _annotationsFound[declaration] = new Set<InstanceMirror>();
+    }
+    if (_annotationsFound[declaration].contains(meta)) continue;
+
+    _annotationsFound[declaration].add(meta);
+
+    // Initialize super classes first, this is the only exception to the
+    // post-order rule.
+    if (declaration is ClassMirror && declaration.superclass != null) {
+      _readAnnotations(declaration.superclass);
+    }
+
+    meta.reflectee.initialize(declaration);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,9 @@
+name: static_init
+version: 0.0.0
+author: Polymer.dart Authors <web@dartlang.org>
+description: Generic building blocks for doing static initialization.
+dependencies:
+dev_dependencies:
+  unittest: '>=0.10.0 <0.12.0'
+environment:
+  sdk: '>=1.4.0 <2.0.0'

--- a/test/bar.dart
+++ b/test/bar.dart
@@ -1,6 +1,7 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+@initializeTracker
 library static_init.test.bar;
 
 import 'foo.dart';  // Make sure cycles are ok.

--- a/test/bar.dart
+++ b/test/bar.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.test.bar;
+
+import 'foo.dart';  // Make sure cycles are ok.
+import 'initialize_tracker.dart';
+
+// Foo should be initialized first.
+@initializeTracker
+class Bar extends Foo {}
+
+@initializeTracker
+bar() {}

--- a/test/foo.dart
+++ b/test/foo.dart
@@ -1,6 +1,7 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+@initializeTracker
 library static_init.test.foo;
 
 import 'bar.dart'; // For the annotations.

--- a/test/foo.dart
+++ b/test/foo.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.test.foo;
+
+import 'bar.dart'; // For the annotations.
+import 'initialize_tracker.dart';
+
+@initializeTracker
+class Foo {}
+
+@initializeTracker
+fooBar() {}
+
+@initializeTracker
+foo() {}

--- a/test/init_method_test.dart
+++ b/test/init_method_test.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.init_method_test;
+
+import 'package:static_init/static_init.dart';
+import 'package:unittest/unittest.dart';
+import 'package:unittest/compact_vm_config.dart';
+
+int calledFoo = 0;
+int calledBar = 0;
+
+main() {
+  useCompactVMConfiguration();
+
+  // Run all static initializers.
+  run();
+
+  test('initMethod annotation invokes functions once', () {
+    expect(calledFoo, 1);
+    expect(calledBar, 1);
+    // Re-run all static initializers, should be a no-op.
+    run();
+    expect(calledFoo, 1);
+    expect(calledBar, 1);
+  });
+}
+
+@initMethod
+foo() => calledFoo++;
+
+@initMethod
+bar() => calledBar++;

--- a/test/init_method_test.dart
+++ b/test/init_method_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 library static_init.init_method_test;

--- a/test/initialize_tracker.dart
+++ b/test/initialize_tracker.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 library static_init.test.initialize_tracker;

--- a/test/initialize_tracker.dart
+++ b/test/initialize_tracker.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.test.initialize_tracker;
+
+import 'dart:mirrors';
+import 'package:static_init/static_init.dart';
+
+// Static Initializer that just saves everything it sees.
+class InitializeTracker implements StaticInitializer<DeclarationMirror> {
+  static final List<DeclarationMirror> seen = [];
+
+  const InitializeTracker();
+
+  @override
+  initialize(DeclarationMirror t) => seen.add(t);
+}
+
+const initializeTracker = const InitializeTracker();

--- a/test/static_init_test.dart
+++ b/test/static_init_test.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.static_init_test;
+
+import 'foo.dart'; // For the annotations.
+import 'initialize_tracker.dart';
+import 'package:static_init/static_init.dart';
+import 'package:unittest/unittest.dart';
+import 'package:unittest/compact_vm_config.dart';
+
+main() {
+  useCompactVMConfiguration();
+
+  // Run all static initializers.
+  run();
+
+  test('annotations are seen in post-order with superclasses first', () {
+    // Foo comes first because its a superclass of Bar.
+    var expectedNames = [#Foo, #Bar, #bar, #fooBar, #foo, #zap, #Zap];
+    var actualNames = InitializeTracker.seen.map((d) => d.simpleName);
+    expect(actualNames, expectedNames);
+  });
+
+  test('annotations only run once', () {
+    // Run the static initializers again, should be a no-op.
+    var originalSize = InitializeTracker.seen.length;
+    run();
+    expect(InitializeTracker.seen.length, originalSize);
+  });
+}
+
+@initializeTracker
+class Zap {}
+
+@initializeTracker
+zap() {}

--- a/test/static_init_test.dart
+++ b/test/static_init_test.dart
@@ -1,6 +1,7 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+@initializeTracker
 library static_init.static_init_test;
 
 import 'foo.dart'; // For the annotations.
@@ -17,7 +18,9 @@ main() {
 
   test('annotations are seen in post-order with superclasses first', () {
     // Foo comes first because its a superclass of Bar.
-    var expectedNames = [#Foo, #Bar, #bar, #fooBar, #foo, #zap, #Zap];
+    var expectedNames = [#static_init.test.bar, #static_init.test.foo,
+        #static_init.static_init_test, #Foo, #Bar, #bar, #fooBar, #foo, #zap,
+        #Zap];
     var actualNames = InitializeTracker.seen.map((d) => d.simpleName);
     expect(actualNames, expectedNames);
   });


### PR DESCRIPTION
This deviates from the design doc somewhat, differences are listed below:
1. Libraries are visited in post-order, but annotations within the libraries are not visited in text-source order. This is because the ClassMirror implementation doesn't implement the location property. The result is that method annotations execute in text-source order but class annotations are mixed in somewhat arbitrarily.
2. The `initialize` method on the `StaticInitializer` class expects Mirror types. So for example `InitMethod` implements `StaticInitializer<MethodMirror>` instead of `StaticInitializer<Function>`.
