### PR TITLE
add typeFilter and customFilter options

### DIFF
--- a/test/static_init_custom_filter_test.dart
+++ b/test/static_init_custom_filter_test.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.static_init_custom_filter_test;
+
+import 'dart:mirrors';
+import 'package:static_init/static_init.dart';
+import 'package:unittest/unittest.dart';
+import 'package:unittest/compact_vm_config.dart';
+import 'initialize_tracker.dart';
+
+main() {
+  useCompactVMConfiguration();
+
+  test('filter option limits which types of annotations will be ran', () {
+    runPhase(1);
+    // Even though Baz extends Bar, only Baz should be run.
+    expect(getNames(InitializeTracker.seen), [#Baz]);
+    runPhase(2);
+    expect(getNames(InitializeTracker.seen), [#Baz, #foo]);
+    runPhase(3);
+    expect(getNames(InitializeTracker.seen), [#Baz, #foo, #Foo]);
+    runPhase(4);
+    expect(getNames(InitializeTracker.seen), [#Baz, #foo, #Foo, #Bar]);
+
+    // Sanity check, future calls should be no-ops
+    var originalSize = InitializeTracker.seen.length;
+    runPhase(1);
+    runPhase(2);
+    runPhase(3);
+    runPhase(4);
+    run();
+    expect(InitializeTracker.seen.length, originalSize);
+  });
+}
+
+Iterable<Symbol> getNames(Iterable<DeclarationMirror> original) =>
+    original.map((d) => d.simpleName);
+
+runPhase(int phase) {
+  run(customFilter: (InstanceMirror meta) =>
+      meta.reflectee is PhasedInitializer &&
+      (meta.reflectee as PhasedInitializer).phase == phase);
+}
+
+@PhasedInitializer(3)
+class Foo {}
+
+@PhasedInitializer(2)
+foo() {}
+
+@PhasedInitializer(4)
+class Bar {}
+
+@PhasedInitializer(1)
+class Baz extends Bar {}
+
+// Static Initializer that has a phase associated with it, this can be used in
+// combination with a custom filter to run intialization in phases.
+class PhasedInitializer extends InitializeTracker {
+  final int phase;
+
+  const PhasedInitializer(this.phase);
+}

--- a/test/static_init_type_filter_test.dart
+++ b/test/static_init_type_filter_test.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.static_init_type_filter_test;
+
+import 'dart:mirrors';
+import 'package:static_init/static_init.dart';
+import 'package:unittest/unittest.dart';
+import 'package:unittest/compact_vm_config.dart';
+
+// Initializers will mess with this value, and it gets reset to 0 at the
+// start of every test.
+var total;
+
+main() {
+  useCompactVMConfiguration();
+
+  setUp(() {
+    total = 0;
+  });
+
+  test('filter option limits which types of annotations will be ran', () {
+    run(typeFilter: const [_Adder]);
+    expect(total, 2);
+    run(typeFilter: const [_Subtractor]);
+    expect(total, 0);
+
+    // Sanity check, future calls should be no-ops
+    run(typeFilter: const [_Adder]);
+    expect(total, 0);
+    run(typeFilter: const [_Subtractor]);
+    expect(total, 0);
+  });
+}
+
+@adder
+a() {}
+@subtractor
+b() {}
+@adder
+@subtractor
+c() {}
+
+// Static Initializer that increments `total` by one.
+class _Adder implements StaticInitializer<DeclarationMirror> {
+  const _Adder();
+
+  @override
+  initialize(DeclarationMirror t) => total++;
+}
+const adder = const _Adder();
+
+// Static Initializer that decrements `total` by one.
+class _Subtractor implements StaticInitializer<DeclarationMirror> {
+  const _Subtractor();
+
+  @override
+  initialize(DeclarationMirror t) => total--;
+}
+const subtractor = const _Subtractor();


### PR DESCRIPTION
Note that in the design doc their is only one `filter` argument, which is analogous to `typeFilter` here. It is simple enough to add the `customFilter` as well though which is much more powerful, so I think its worth doing both. For instance if you look at the customFilter test that I added it makes running initializers in phases really easy.
