### PR TITLE
Initial commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Pub files.
-build
+/build/
 packages
 .pub
 pubspec.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Pub files.
+build
+packages
+.pub
+pubspec.lock
+
+# Files created by dart2js.
+*.dart.js
+*.dart.precompiled.js
+*.js_
+*.js.deps
+*.js.map
+*.sw?
+
+# Intellij files.
+.idea/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+Copyright 2013, the Dart project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2013, the Dart project authors. All rights reserved.
+Copyright 2015, the Dart project authors. All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:

--- a/lib/src/init_method.dart
+++ b/lib/src/init_method.dart
@@ -7,21 +7,12 @@ part of static_init;
 /// automatically when calling static_init.run(). This class is private because
 /// it shouldn't be used directly in annotations, instead use the `initMethod`
 /// singleton below.
-class _InitMethod implements StaticInitializer<MethodMirror> {
+typedef dynamic _ZeroArg();
+class _InitMethod implements StaticInitializer<_ZeroArg> {
   const _InitMethod();
 
   @override
-  initialize(MethodMirror method) {
-    if (!method.isStatic) {
-      throw 'Methods marked with @initMethod should be static, '
-            '${method.simpleName} is not.';
-    }
-    if (method.parameters.any((p) => !p.isOptional)) {
-      throw 'Methods marked with @initMethod should take no arguments, '
-            '${method.simpleName} expects some.';
-    }
-    (method.owner as ObjectMirror).invoke(method.simpleName, const []);
-  }
+  initialize(_ZeroArg method) => method();
 }
 
 /// We only ever need one instance of the `_InitMethod` class, this is it.

--- a/lib/src/init_method.dart
+++ b/lib/src/init_method.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 part of static_init;

--- a/lib/src/init_method.dart
+++ b/lib/src/init_method.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+part of static_init;
+
+/// Metadata used to label static or top-level methods that are called
+/// automatically when calling static_init.run(). This class is private because
+/// it shouldn't be used directly in annotations, instead use the `initMethod`
+/// singleton below.
+class _InitMethod implements StaticInitializer<MethodMirror> {
+  const _InitMethod();
+
+  @override
+  initialize(MethodMirror method) {
+    if (!method.isStatic) {
+      throw 'Methods marked with @initMethod should be static, '
+            '${method.simpleName} is not.';
+    }
+    if (method.parameters.any((p) => !p.isOptional)) {
+      throw 'Methods marked with @initMethod should take no arguments, '
+            '${method.simpleName} expects some.';
+    }
+    (method.owner as ObjectMirror).invoke(method.simpleName, const []);
+  }
+}
+
+/// We only ever need one instance of the `_InitMethod` class, this is it.
+const initMethod = const _InitMethod();

--- a/lib/src/mirror_loader.dart
+++ b/lib/src/mirror_loader.dart
@@ -55,7 +55,7 @@ class StaticInitializationCrawler {
   // Reads StaticInitializer annotations on this library and all its
   // dependencies in post-order.
   void _readLibraryDeclarations(LibraryMirror lib,
-                                [Set<LibraryMirror> librariesSeen]) {
+      [Set<LibraryMirror> librariesSeen]) {
     if (librariesSeen == null) librariesSeen = new Set<LibraryMirror>();
     librariesSeen.add(lib);
 
@@ -83,26 +83,24 @@ class StaticInitializationCrawler {
     }
   }
 
-  Iterable<LibraryDependencyMirror>
-      _sortedLibraryDependencies(LibraryMirror lib) =>
-    new List.from(lib.libraryDependencies)
-      ..sort((a, b) {
-        var aScheme = a.targetLibrary.uri.scheme;
-        var bScheme = b.targetLibrary.uri.scheme;
-        if (aScheme != 'file' && bScheme == 'file') return -1;
-        if (bScheme != 'file' && aScheme == 'file') return 1;
-        return _relativeLibraryUri(a).compareTo(_relativeLibraryUri(b));
-      });
+  Iterable<LibraryDependencyMirror> _sortedLibraryDependencies(
+      LibraryMirror lib) => new List.from(lib.libraryDependencies)
+        ..sort((a, b) {
+          var aScheme = a.targetLibrary.uri.scheme;
+          var bScheme = b.targetLibrary.uri.scheme;
+          if (aScheme != 'file' && bScheme == 'file') return -1;
+          if (bScheme != 'file' && aScheme == 'file') return 1;
+          return _relativeLibraryUri(a).compareTo(_relativeLibraryUri(b));
+        });
 
   String _relativeLibraryUri(LibraryDependencyMirror lib) {
-    if (lib.targetLibrary.uri.scheme == 'file'
-        && lib.sourceLibrary.uri.scheme == 'file') {
+    if (lib.targetLibrary.uri.scheme == 'file' &&
+        lib.sourceLibrary.uri.scheme == 'file') {
       return path.relative(lib.targetLibrary.uri.path,
           from: path.dirname(lib.sourceLibrary.uri.path));
     }
     return lib.targetLibrary.uri.toString();
   }
-
 
   Iterable<DeclarationMirror> _sortedLibraryDeclarations(LibraryMirror lib) =>
       lib.declarations.values

--- a/lib/src/mirror_loader.dart
+++ b/lib/src/mirror_loader.dart
@@ -86,8 +86,13 @@ class StaticInitializationCrawler {
   Iterable<LibraryDependencyMirror>
       _sortedLibraryDependencies(LibraryMirror lib) =>
     new List.from(lib.libraryDependencies)
-      ..sort((a, b) =>
-          _relativeLibraryUri(a).compareTo(_relativeLibraryUri(b)));
+      ..sort((a, b) {
+        var aScheme = a.targetLibrary.uri.scheme;
+        var bScheme = b.targetLibrary.uri.scheme;
+        if (aScheme != 'file' && bScheme == 'file') return -1;
+        if (bScheme != 'file' && aScheme == 'file') return 1;
+        return _relativeLibraryUri(a).compareTo(_relativeLibraryUri(b));
+      });
 
   String _relativeLibraryUri(LibraryDependencyMirror lib) {
     if (lib.targetLibrary.uri.scheme == 'file'

--- a/lib/src/mirror_loader.dart
+++ b/lib/src/mirror_loader.dart
@@ -55,13 +55,13 @@ class StaticInitializationCrawler {
         .then((_) => _runInitQueue());
   }
 
-  /// Reads and executes StaticInitializer annotations on this library and all
-  /// its dependencies in post-order.
+  // Reads StaticInitializer annotations on this library and all its
+  // dependencies in post-order.
   void _readLibraryDeclarations(LibraryMirror lib) {
     _librariesSeen.add(lib);
 
     // First visit all our dependencies.
-    for (var dependency in lib.libraryDependencies) {
+    for (var dependency in _sortedLibraryDependencies(lib)) {
       if (_librariesSeen.contains(dependency.targetLibrary)) continue;
       _readLibraryDeclarations(dependency.targetLibrary);
     }
@@ -70,47 +70,110 @@ class StaticInitializationCrawler {
     _readAnnotations(lib);
 
     // Last, parse all class and method annotations.
-    lib.declarations.values
-        .where((d) => d is ClassMirror || d is MethodMirror)
-        .forEach((DeclarationMirror d) => _readAnnotations(d));
+    for (var declaration in _sortedLibraryDeclarations(lib)) {
+      _readAnnotations(declaration);
+      // Check classes for static annotations which are not supported
+      if (declaration is ClassMirror) {
+        for (var classDeclaration in declaration.declarations.values) {
+          _readAnnotations(classDeclaration);
+        }
+      }
+    }
   }
 
+  Iterable<LibraryDependencyMirror>
+      _sortedLibraryDependencies(LibraryMirror lib) =>
+    lib.libraryDependencies
+      ..sort((a, b) => _targetLibraryName(a).compareTo(_targetLibraryName(b)));
+
+  String _targetLibraryName(LibraryDependencyMirror lib) =>
+      MirrorSystem.getName(lib.targetLibrary.qualifiedName);
+
+  Iterable<DeclarationMirror> _sortedLibraryDeclarations(LibraryMirror lib) =>
+      lib.declarations.values
+          .where((d) => d is ClassMirror || d is MethodMirror)
+          .toList()
+          ..sort((a, b) {
+            if (a.runtimeType == b.runtimeType) {
+              return _declarationName(a).compareTo(_declarationName(b));
+            }
+            if (a is MethodMirror && b is ClassMirror) return -1;
+            if (a is ClassMirror && b is MethodMirror) return 1;
+            return 0;
+          });
+
+  String _declarationName(DeclarationMirror declaration) =>
+      MirrorSystem.getName(declaration.qualifiedName);
+
+  // Reads annotations on declarations and adds them to `_initQueue` if they are
+  // static initializers.
   void _readAnnotations(DeclarationMirror declaration) {
-    declaration.metadata.where((m) {
-      if (m.reflectee is! StaticInitializer) return false;
-      if (typeFilter != null &&
-          !typeFilter.any((t) => m.reflectee.runtimeType == t)) {
-        return false;
-      }
-      if (customFilter != null && !customFilter(m.reflectee)) return false;
-      return true;
-    }).forEach((meta) {
-      if (!_annotationsFound.containsKey(declaration)) {
-        _annotationsFound[declaration] = new Set<InstanceMirror>();
-      }
-      if (_annotationsFound[declaration].contains(meta)) return;
+    var annotations =
+        declaration.metadata.where((m) => _filterMetadata(declaration, m));
+    for (var meta in annotations) {
       _annotationsFound[declaration].add(meta);
 
-      // Initialize super classes first, this is the only exception to the
-      // post-order rule.
+      // Initialize super classes first, if they are in the same library,
+      // otherwise we throw an error. This can only be the case if there are
+      // cycles in the imports.
       if (declaration is ClassMirror && declaration.superclass != null) {
-        _readAnnotations(declaration.superclass);
+        if (declaration.superclass.owner == declaration.owner) {
+          _readAnnotations(declaration.superclass);
+        } else {
+          var superMetas = declaration.superclass.metadata
+              .where((m) => _filterMetadata(declaration.superclass, m))
+              .toList();
+          if (superMetas.isNotEmpty) {
+            throw new UnsupportedError(
+                'We have detected a cycle in your import graph when running '
+                'static initializers on ${declaration.qualifiedName}. This means '
+                'the super class ${declaration.superclass.qualifiedName} has a '
+                'dependency on this library (possibly transitive).');
+          }
+        }
       }
 
       var annotatedValue;
       if (declaration is ClassMirror) {
         annotatedValue = declaration.reflectedType;
       } else if (declaration is MethodMirror) {
-        if (!declaration.isStatic) {
-          throw new UnsupportedError(
-              'Only static methods are supported for StaticInitializers');
+        if (declaration.owner is! LibraryMirror) {
+          throw _TOP_LEVEL_FUNCTIONS_ONLY;
         }
         annotatedValue = (declaration.owner as ObjectMirror)
             .getField(declaration.simpleName).reflectee;
-      } else {
+      } else if (declaration is LibraryMirror) {
         annotatedValue = declaration.qualifiedName;
+      } else {
+        throw _UNSUPPORTED_DECLARATION;
       }
       _initQueue.addLast(() => meta.reflectee.initialize(annotatedValue));
-    });
+    }
+    ;
+  }
+
+  bool _filterMetadata(DeclarationMirror declaration, InstanceMirror meta) {
+    // We only care about StaticInitializer annotations
+    if (meta.reflectee is! StaticInitializer) return false;
+    // Respect the typeFilter
+    if (typeFilter != null &&
+        !typeFilter.any((t) => meta.reflectee.runtimeType == t)) {
+      return false;
+    }
+    // Respect the customFilter
+    if (customFilter != null && !customFilter(meta.reflectee)) return false;
+    // Filter out already seen annotations
+    if (!_annotationsFound.containsKey(declaration)) {
+      _annotationsFound[declaration] = new Set<InstanceMirror>();
+    }
+    if (_annotationsFound[declaration].contains(meta)) return false;
+    return true;
   }
 }
+
+final _TOP_LEVEL_FUNCTIONS_ONLY = new UnsupportedError(
+    'Only top level methods are supported for StaticInitializers');
+
+final _UNSUPPORTED_DECLARATION = new UnsupportedError(
+    'StaticInitializers are only supported on libraries, classes, and top '
+    'level methods');

--- a/lib/src/mirror_loader.dart
+++ b/lib/src/mirror_loader.dart
@@ -40,19 +40,18 @@ class StaticInitializationCrawler {
   // The primary function in this class, invoke it to crawl and call all the
   // annotations.
   Future run() {
-    // Parse everything into the two queues.
     _readLibraryDeclarations(_root);
-
-    // Empty the init queue.
     return _runInitQueue();
   }
 
   Future _runInitQueue() {
     if (_initQueue.isEmpty) return new Future.value(null);
-    // Remove and invoke the next item.
-    var val = _initQueue.removeFirst()();
-    return (val is Future ? val : new Future.value(null))
-        .then((_) => _runInitQueue());
+
+    var initializer = _initQueue.removeFirst();
+    var val = initializer();
+    if (val is! Future) val = new Future.value(val);
+
+    return val.then((_) => _runInitQueue());
   }
 
   // Reads StaticInitializer annotations on this library and all its

--- a/lib/src/mirror_loader.dart
+++ b/lib/src/mirror_loader.dart
@@ -1,0 +1,113 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.mirror_loader;
+
+import 'dart:collection' show ListQueue;
+import 'dart:mirrors';
+import 'package:static_init/static_init.dart';
+
+// Crawls a library and all its dependencies for `StaticInitializer`
+// annotations using mirrors
+class StaticInitializationCrawler {
+  // Set of all visited annotations, keys are the declarations that were
+  // annotated, values are the annotations that have been processed.
+  static final _annotationsFound =
+      new Map<DeclarationMirror, Set<InstanceMirror>>();
+
+  // If non-null, then only these annotations should be processed.
+  final List<Type> typeFilter;
+
+  // If non-null, then only annotations which return true when passed to this
+  // function will be processed.
+  final InitializerFilter customFilter;
+
+  // All the libraries we have seen so far.
+  final Set<LibraryMirror> _librariesSeen = new Set<LibraryMirror>();
+
+  // The root library that we start parsing from.
+  LibraryMirror _root;
+
+  /// Queues for pending intialization functions to run.
+  final _libraryQueue = new ListQueue<Function>();
+  final _otherQueue = new ListQueue<Function>();
+
+  StaticInitializationCrawler(
+      this.typeFilter, this.customFilter, {LibraryMirror root}) {
+    _root = root == null ? currentMirrorSystem().isolate.rootLibrary : root;
+  }
+
+  // The primary function in this class, invoke it to crawl and call all the
+  // annotations.
+  run() {
+    // Parse everything into the two queues.
+    _readLibraryDeclarations(_root);
+
+    // First empty the _libraryQueue, then the _otherQueue.
+    while (_libraryQueue.isNotEmpty) _libraryQueue.removeFirst()();
+    while (_otherQueue.isNotEmpty) _otherQueue.removeFirst()();
+  }
+
+  /// Reads and executes StaticInitializer annotations on this library and all
+  /// its dependencies in post-order.
+  void _readLibraryDeclarations(LibraryMirror lib) {
+    _librariesSeen.add(lib);
+
+    // First visit all our dependencies.
+    for (var dependency in lib.libraryDependencies) {
+      if (_librariesSeen.contains(dependency.targetLibrary)) continue;
+      _readLibraryDeclarations(dependency.targetLibrary);
+    }
+
+    // Second parse the library directive annotations.
+    _readAnnotations(lib, _libraryQueue);
+
+    // Last, parse all class and method annotations.
+    lib .declarations
+        .values
+        .where((d) => d is ClassMirror || d is MethodMirror)
+        .forEach((DeclarationMirror d) => _readAnnotations(d, _otherQueue));
+  }
+
+  void _readAnnotations(DeclarationMirror declaration,
+                        ListQueue<Function> queue) {
+    declaration
+        .metadata
+        .where((m) {
+          if (m.reflectee is! StaticInitializer) return false;
+          if (typeFilter != null &&
+              !typeFilter.any((t) => m.reflectee.runtimeType == t)) {
+            return false;
+          }
+          if (customFilter != null && !customFilter(m.reflectee)) return false;
+          return true;
+        })
+        .forEach((meta) {
+          if (!_annotationsFound.containsKey(declaration)) {
+            _annotationsFound[declaration] = new Set<InstanceMirror>();
+          }
+          if (_annotationsFound[declaration].contains(meta)) return;
+          _annotationsFound[declaration].add(meta);
+
+          // Initialize super classes first, this is the only exception to the
+          // post-order rule.
+          if (declaration is ClassMirror && declaration.superclass != null) {
+            _readAnnotations(declaration.superclass, queue);
+          }
+
+          queue.addLast(() {
+            var annotatedValue;
+            if (declaration is ClassMirror) {
+              annotatedValue = declaration.reflectedType;
+            } else if (declaration is MethodMirror) {
+              annotatedValue =
+                  () => (declaration.owner as ObjectMirror)
+                            .invoke(declaration.simpleName, const []);
+            } else {
+              annotatedValue = declaration.qualifiedName;
+            }
+            meta.reflectee.initialize(annotatedValue);
+          });
+        });
+  }
+}

--- a/lib/src/static_initializer.dart
+++ b/lib/src/static_initializer.dart
@@ -7,12 +7,12 @@ part of static_init;
 ///
 /// Hello world example:
 ///
-///   class Print implements StaticInitializer<ClassMirror> {
+///   class Print implements StaticInitializer<Type> {
 ///     final String message;
 ///     const Print(this.message);
 ///
 ///     @override
-///     initialize(ClassMirror) => print('${t.reflectedType} says `$message`');
+///     initialize(Type t) => print('$t says `$message`');
 ///   }
 ///
 ///   @Print('hello world!')
@@ -23,3 +23,6 @@ part of static_init;
 abstract class StaticInitializer<T> {
   dynamic initialize(T target);
 }
+
+/// Typedef for a custom filter function.
+typedef bool InitializerFilter(StaticInitializer initializer);

--- a/lib/src/static_initializer.dart
+++ b/lib/src/static_initializer.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+part of static_init;
+
+/// Implement this class to create your own initializer.
+///
+/// Hello world example:
+///
+///   class Print implements StaticInitializer<ClassMirror> {
+///     final String message;
+///     const Print(this.message);
+///
+///     @override
+///     initialize(ClassMirror) => print('${t.reflectedType} says `$message`');
+///   }
+///
+///   @Print('hello world!')
+///   class Foo {}
+///
+/// Call run() from your main and this will print 'Foo says `hello world!`'
+///
+abstract class StaticInitializer<T> {
+  dynamic initialize(T target);
+}

--- a/lib/src/static_initializer.dart
+++ b/lib/src/static_initializer.dart
@@ -18,7 +18,7 @@ part of static_init;
 ///   @Print('hello world!')
 ///   class Foo {}
 ///
-/// Call run() from your main and this will print 'Foo says `hello world!`'
+/// Call [run] from your main and this will print 'Foo says `hello world!`'
 ///
 abstract class StaticInitializer<T> {
   dynamic initialize(T target);

--- a/lib/src/static_initializer.dart
+++ b/lib/src/static_initializer.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 part of static_init;

--- a/lib/static_init.dart
+++ b/lib/static_init.dart
@@ -5,6 +5,7 @@ library static_init;
 
 // The transformer will replace this with a static_loader.
 import 'src/mirror_loader.dart';
+import 'dart:async';
 
 part 'src/init_method.dart';
 part 'src/static_initializer.dart';
@@ -12,6 +13,5 @@ part 'src/static_initializer.dart';
 /// Top level function which crawls the dependency graph and runs initializers.
 /// If `typeFilter` is supplied then only those types of annotations will be
 /// parsed.
-void run({List<Type> typeFilter, InitializerFilter customFilter}) {
-  new StaticInitializationCrawler(typeFilter, customFilter).run();
-}
+Future run({List<Type> typeFilter, InitializerFilter customFilter}) =>
+    new StaticInitializationCrawler(typeFilter, customFilter).run();

--- a/lib/static_init.dart
+++ b/lib/static_init.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init;
+
+import 'dart:mirrors';
+
+part 'src/init_method.dart';
+part 'src/static_initializer.dart';
+
+/// The root library to start from.
+final _root = currentMirrorSystem().isolate.rootLibrary;
+
+/// Set of all visited annotations, keys are the declarations that were
+/// annotated, values are the annotations that have been processed.
+final _annotationsFound = new Map<DeclarationMirror, Set<InstanceMirror>>();
+
+/// Top level function which crawls the dependency graph and runs initializers.
+void run() {
+  _readLibraryDeclarations(_root);
+}
+
+/// Reads and executes StaticInitializer annotations on this library and all its
+/// dependencies in post-order.
+void _readLibraryDeclarations(
+    LibraryMirror library, [Set<LibraryMirror> librariesSeen]) {
+  if (librariesSeen == null) librariesSeen = new Set<LibraryMirror>();
+  librariesSeen.add(library);
+
+  // First visit all our dependencies.
+  for (var dependency in library.libraryDependencies) {
+    if (librariesSeen.contains(dependency.targetLibrary)) continue;
+    _readLibraryDeclarations(dependency.targetLibrary, librariesSeen);
+  }
+
+  // Then parse all class and method annotations in this library.
+  library
+      .declarations
+      .values
+      .where((d) => d is ClassMirror || d is MethodMirror)
+      .forEach((DeclarationMirror d) => _readAnnotations(d));
+}
+
+void _readAnnotations(DeclarationMirror declaration) {
+  for (var meta in declaration.metadata) {
+    if (meta.reflectee is! StaticInitializer) continue;
+    if (!_annotationsFound.containsKey(declaration)) {
+      _annotationsFound[declaration] = new Set<InstanceMirror>();
+    }
+    if (_annotationsFound[declaration].contains(meta)) continue;
+
+    _annotationsFound[declaration].add(meta);
+
+    // Initialize super classes first, this is the only exception to the
+    // post-order rule.
+    if (declaration is ClassMirror && declaration.superclass != null) {
+      _readAnnotations(declaration.superclass);
+    }
+
+    meta.reflectee.initialize(declaration);
+  }
+}

--- a/lib/static_init.dart
+++ b/lib/static_init.dart
@@ -3,111 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 library static_init;
 
-import 'dart:collection' show ListQueue;
-import 'dart:mirrors';
+// The transformer will replace this with a static_loader.
+import 'src/mirror_loader.dart';
 
 part 'src/init_method.dart';
 part 'src/static_initializer.dart';
-
-/// Typedef for a custom filter function.
-typedef bool InitializerFilter(InstanceMirror meta);
 
 /// Top level function which crawls the dependency graph and runs initializers.
 /// If `typeFilter` is supplied then only those types of annotations will be
 /// parsed.
 void run({List<Type> typeFilter, InitializerFilter customFilter}) {
-  new _StaticInitializationCrawler(typeFilter, customFilter).run();
-}
-
-// Crawls a library and all its dependencies for `StaticInitializer`
-// annotations.
-class _StaticInitializationCrawler {
-  // Set of all visited annotations, keys are the declarations that were
-  // annotated, values are the annotations that have been processed.
-  static final _annotationsFound =
-      new Map<DeclarationMirror, Set<InstanceMirror>>();
-
-  // If non-null, then only these annotations should be processed.
-  final List<Type> typeFilter;
-
-  // If non-null, then only annotations which return true when passed to this
-  // function will be processed.
-  final InitializerFilter customFilter;
-
-  // All the libraries we have seen so far.
-  final Set<LibraryMirror> _librariesSeen = new Set<LibraryMirror>();
-
-  // The root library that we start parsing from.
-  LibraryMirror _root;
-
-  /// Queues for pending intialization functions to run.
-  final _libraryQueue = new ListQueue<Function>();
-  final _otherQueue = new ListQueue<Function>();
-
-  _StaticInitializationCrawler(
-      this.typeFilter, this.customFilter, {LibraryMirror root}) {
-    _root = root == null ? currentMirrorSystem().isolate.rootLibrary : root;
-  }
-
-  // The primary function in this class, invoke it to crawl and call all the
-  // annotations.
-  run() {
-    // Parse everything into the two queues.
-    _readLibraryDeclarations(_root);
-
-    // First empty the _libraryQueue, then the _otherQueue.
-    while (_libraryQueue.isNotEmpty) _libraryQueue.removeFirst()();
-    while (_otherQueue.isNotEmpty) _otherQueue.removeFirst()();
-  }
-
-  /// Reads and executes StaticInitializer annotations on this library and all
-  /// its dependencies in post-order.
-  void _readLibraryDeclarations(LibraryMirror lib) {
-    _librariesSeen.add(lib);
-
-    // First visit all our dependencies.
-    for (var dependency in lib.libraryDependencies) {
-      if (_librariesSeen.contains(dependency.targetLibrary)) continue;
-      _readLibraryDeclarations(dependency.targetLibrary);
-    }
-
-    // Second parse the library directive annotations.
-    _readAnnotations(lib, _libraryQueue);
-
-    // Last, parse all class and method annotations.
-    lib .declarations
-        .values
-        .where((d) => d is ClassMirror || d is MethodMirror)
-        .forEach((DeclarationMirror d) => _readAnnotations(d, _otherQueue));
-  }
-
-  void _readAnnotations(DeclarationMirror declaration,
-                        ListQueue<Function> queue) {
-    declaration
-        .metadata
-        .where((m) {
-          if (m.reflectee is! StaticInitializer) return false;
-          if (typeFilter != null &&
-              !typeFilter.any((t) => m.reflectee.runtimeType == t)) {
-            return false;
-          }
-          if (customFilter != null && !customFilter(m)) return false;
-          return true;
-        })
-        .forEach((meta) {
-          if (!_annotationsFound.containsKey(declaration)) {
-            _annotationsFound[declaration] = new Set<InstanceMirror>();
-          }
-          if (_annotationsFound[declaration].contains(meta)) return;
-          _annotationsFound[declaration].add(meta);
-
-          // Initialize super classes first, this is the only exception to the
-          // post-order rule.
-          if (declaration is ClassMirror && declaration.superclass != null) {
-            _readAnnotations(declaration.superclass, queue);
-          }
-
-          queue.addLast(() => meta.reflectee.initialize(declaration));
-        });
-  }
+  new StaticInitializationCrawler(typeFilter, customFilter).run();
 }

--- a/lib/static_init.dart
+++ b/lib/static_init.dart
@@ -10,8 +10,7 @@ import 'dart:async';
 part 'src/init_method.dart';
 part 'src/static_initializer.dart';
 
-/// Top level function which crawls the dependency graph and runs initializers.
-/// If `typeFilter` is supplied then only those types of annotations will be
-/// parsed.
+/// Executes initializers in every library discovered by crawling Dart imports,
+/// exports, and part directives.
 Future run({List<Type> typeFilter, InitializerFilter customFilter}) =>
     new StaticInitializationCrawler(typeFilter, customFilter).run();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,9 @@
+name: static_init
+version: 0.0.0
+author: Polymer.dart Authors <web@dartlang.org>
+description: Generic building blocks for doing static initialization.
+dependencies:
+dev_dependencies:
+  unittest: '>=0.10.0 <0.12.0'
+environment:
+  sdk: '>=1.4.0 <2.0.0'

--- a/test/bar.dart
+++ b/test/bar.dart
@@ -12,4 +12,4 @@ import 'initialize_tracker.dart';
 class Bar extends Foo {}
 
 @initializeTracker
-bar() => 'bar';
+bar() {}

--- a/test/bar.dart
+++ b/test/bar.dart
@@ -1,6 +1,7 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+@initializeTracker
 library static_init.test.bar;
 
 import 'foo.dart';  // Make sure cycles are ok.

--- a/test/bar.dart
+++ b/test/bar.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.test.bar;
+
+import 'foo.dart';  // Make sure cycles are ok.
+import 'initialize_tracker.dart';
+
+// Foo should be initialized first.
+@initializeTracker
+class Bar extends Foo {}
+
+@initializeTracker
+bar() {}

--- a/test/bar.dart
+++ b/test/bar.dart
@@ -12,4 +12,4 @@ import 'initialize_tracker.dart';
 class Bar extends Foo {}
 
 @initializeTracker
-bar() {}
+bar() => 'bar';

--- a/test/bar.dart
+++ b/test/bar.dart
@@ -4,7 +4,7 @@
 @initializeTracker
 library static_init.test.bar;
 
-import 'foo.dart';  // Make sure cycles are ok.
+import 'foo.dart'; // Make sure cycles are ok.
 import 'initialize_tracker.dart';
 
 // Foo should be initialized first.

--- a/test/cycle_a.dart
+++ b/test/cycle_a.dart
@@ -1,15 +1,10 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-@initializeTracker
-library static_init.test.bar;
+library static_init.test.cycle_a;
 
-import 'foo.dart';
 import 'initialize_tracker.dart';
-
-// Foo should be initialized first.
-@initializeTracker
-class Bar extends Foo {}
+import 'cycle_b.dart';
 
 @initializeTracker
-bar() {}
+class CycleA {}

--- a/test/cycle_b.dart
+++ b/test/cycle_b.dart
@@ -1,15 +1,10 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-@initializeTracker
-library static_init.test.bar;
+library static_init.test.cycle_b;
 
-import 'foo.dart';
 import 'initialize_tracker.dart';
-
-// Foo should be initialized first.
-@initializeTracker
-class Bar extends Foo {}
+import 'cycle_a.dart';
 
 @initializeTracker
-bar() {}
+class CycleB extends CycleA {}

--- a/test/foo.dart
+++ b/test/foo.dart
@@ -11,7 +11,7 @@ import 'initialize_tracker.dart';
 class Foo {}
 
 @initializeTracker
-fooBar() => 'fooBar';
+fooBar() {}
 
 @initializeTracker
-foo() => 'foo';
+foo() {}

--- a/test/foo.dart
+++ b/test/foo.dart
@@ -1,6 +1,7 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+@initializeTracker
 library static_init.test.foo;
 
 import 'bar.dart'; // For the annotations.

--- a/test/foo.dart
+++ b/test/foo.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.test.foo;
+
+import 'bar.dart'; // For the annotations.
+import 'initialize_tracker.dart';
+
+@initializeTracker
+class Foo {}
+
+@initializeTracker
+fooBar() {}
+
+@initializeTracker
+foo() {}

--- a/test/foo.dart
+++ b/test/foo.dart
@@ -4,7 +4,6 @@
 @initializeTracker
 library static_init.test.foo;
 
-export 'bar.dart';
 import 'initialize_tracker.dart';
 
 @initializeTracker

--- a/test/foo.dart
+++ b/test/foo.dart
@@ -4,14 +4,14 @@
 @initializeTracker
 library static_init.test.foo;
 
-import 'bar.dart'; // For the annotations.
+export 'bar.dart';
 import 'initialize_tracker.dart';
 
 @initializeTracker
 class Foo {}
 
 @initializeTracker
-fooBar() {}
+fooBar() => 'fooBar';
 
 @initializeTracker
-foo() {}
+foo() => 'foo';

--- a/test/init_method_test.dart
+++ b/test/init_method_test.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.init_method_test;
+
+import 'package:static_init/static_init.dart';
+import 'package:unittest/unittest.dart';
+import 'package:unittest/compact_vm_config.dart';
+
+int calledFoo = 0;
+int calledBar = 0;
+
+main() {
+  useCompactVMConfiguration();
+
+  // Run all static initializers.
+  run();
+
+  test('initMethod annotation invokes functions once', () {
+    expect(calledFoo, 1);
+    expect(calledBar, 1);
+    // Re-run all static initializers, should be a no-op.
+    run();
+    expect(calledFoo, 1);
+    expect(calledBar, 1);
+  });
+}
+
+@initMethod
+foo() => calledFoo++;
+
+@initMethod
+bar() => calledBar++;

--- a/test/init_method_test.dart
+++ b/test/init_method_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 library static_init.init_method_test;

--- a/test/init_method_test.dart
+++ b/test/init_method_test.dart
@@ -15,7 +15,6 @@ main() {
 
   // Run all static initializers.
   run().then((_) {
-
     test('initMethod annotation invokes functions once', () {
       expect(calledFoo, 1);
       expect(calledBar, 1);
@@ -25,7 +24,6 @@ main() {
         expect(calledBar, 1);
       });
     });
-
   });
 }
 

--- a/test/init_method_test.dart
+++ b/test/init_method_test.dart
@@ -14,15 +14,18 @@ main() {
   useCompactVMConfiguration();
 
   // Run all static initializers.
-  run();
+  run().then((_) {
 
-  test('initMethod annotation invokes functions once', () {
-    expect(calledFoo, 1);
-    expect(calledBar, 1);
-    // Re-run all static initializers, should be a no-op.
-    run();
-    expect(calledFoo, 1);
-    expect(calledBar, 1);
+    test('initMethod annotation invokes functions once', () {
+      expect(calledFoo, 1);
+      expect(calledBar, 1);
+      // Re-run all static initializers, should be a no-op.
+      return run().then((_) {
+        expect(calledFoo, 1);
+        expect(calledBar, 1);
+      });
+    });
+
   });
 }
 

--- a/test/initialize_tracker.dart
+++ b/test/initialize_tracker.dart
@@ -7,13 +7,20 @@ import 'dart:mirrors';
 import 'package:static_init/static_init.dart';
 
 // Static Initializer that just saves everything it sees.
-class InitializeTracker implements StaticInitializer<DeclarationMirror> {
-  static final List<DeclarationMirror> seen = [];
+class InitializeTracker implements StaticInitializer<dynamic> {
+  static final List seen = [];
 
   const InitializeTracker();
 
   @override
-  initialize(DeclarationMirror t) => seen.add(t);
+  void initialize(value) {
+    // invoke functions and add their return value, makes testing easier.
+    if (value is Function) {
+      seen.add((value() as InstanceMirror).reflectee);
+    } else {
+      seen.add(value);
+    }
+  }
 }
 
 const initializeTracker = const InitializeTracker();

--- a/test/initialize_tracker.dart
+++ b/test/initialize_tracker.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 library static_init.test.initialize_tracker;

--- a/test/initialize_tracker.dart
+++ b/test/initialize_tracker.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.test.initialize_tracker;
+
+import 'dart:mirrors';
+import 'package:static_init/static_init.dart';
+
+// Static Initializer that just saves everything it sees.
+class InitializeTracker implements StaticInitializer<DeclarationMirror> {
+  static final List<DeclarationMirror> seen = [];
+
+  const InitializeTracker();
+
+  @override
+  initialize(DeclarationMirror t) => seen.add(t);
+}
+
+const initializeTracker = const InitializeTracker();

--- a/test/initialize_tracker.dart
+++ b/test/initialize_tracker.dart
@@ -13,14 +13,7 @@ class InitializeTracker implements StaticInitializer<dynamic> {
   const InitializeTracker();
 
   @override
-  void initialize(value) {
-    // invoke functions and add their return value, makes testing easier.
-    if (value is Function) {
-      seen.add((value() as InstanceMirror).reflectee);
-    } else {
-      seen.add(value);
-    }
-  }
+  void initialize(value) => seen.add(value);
 }
 
 const initializeTracker = const InitializeTracker();

--- a/test/static_init_custom_filter_test.dart
+++ b/test/static_init_custom_filter_test.dart
@@ -18,11 +18,11 @@ main() {
       // Even though Baz extends Bar, only Baz should be run.
       expect(InitializeTracker.seen, [Baz]);
     }).then((_) => runPhase(2)).then((_) {
-      expect(InitializeTracker.seen, [Baz, 'foo']);
+      expect(InitializeTracker.seen, [Baz, foo]);
     }).then((_) => runPhase(3)).then((_) {
-      expect(InitializeTracker.seen, [Baz, 'foo', Foo]);
+      expect(InitializeTracker.seen, [Baz, foo, Foo]);
     }).then((_) => runPhase(4)).then((_) {
-      expect(InitializeTracker.seen, [Baz, 'foo', Foo, Bar]);
+      expect(InitializeTracker.seen, [Baz, foo, Foo, Bar]);
     }).then((_) {
       originalSize = InitializeTracker.seen.length;
     }).then((_) => runPhase(1))
@@ -43,7 +43,7 @@ Future runPhase(int phase) =>
 class Foo {}
 
 @PhasedInitializer(2)
-foo() => 'foo';
+foo() {}
 
 @PhasedInitializer(4)
 class Bar {}

--- a/test/static_init_custom_filter_test.dart
+++ b/test/static_init_custom_filter_test.dart
@@ -25,19 +25,21 @@ main() {
       expect(InitializeTracker.seen, [Baz, foo, Foo, Bar]);
     }).then((_) {
       originalSize = InitializeTracker.seen.length;
-    }).then((_) => runPhase(1))
-      .then((_) => runPhase(2))
-      .then((_) => runPhase(3))
-      .then((_) => runPhase(4))
-      .then((_) => run()).then((_) {
+    })
+        .then((_) => runPhase(1))
+        .then((_) => runPhase(2))
+        .then((_) => runPhase(3))
+        .then((_) => runPhase(4))
+        .then((_) => run())
+        .then((_) {
       expect(InitializeTracker.seen.length, originalSize);
     });
   });
 }
 
-Future runPhase(int phase) =>
-  run(customFilter: (StaticInitializer meta) =>
-      meta is PhasedInitializer && meta.phase == phase);
+Future runPhase(int phase) => run(
+    customFilter: (StaticInitializer meta) =>
+        meta is PhasedInitializer && meta.phase == phase);
 
 @PhasedInitializer(3)
 class Foo {}

--- a/test/static_init_custom_filter_test.dart
+++ b/test/static_init_custom_filter_test.dart
@@ -15,13 +15,13 @@ main() {
   test('filter option limits which types of annotations will be ran', () {
     runPhase(1);
     // Even though Baz extends Bar, only Baz should be run.
-    expect(getNames(InitializeTracker.seen), [#Baz]);
+    expect(InitializeTracker.seen, [Baz]);
     runPhase(2);
-    expect(getNames(InitializeTracker.seen), [#Baz, #foo]);
+    expect(InitializeTracker.seen, [Baz, 'foo']);
     runPhase(3);
-    expect(getNames(InitializeTracker.seen), [#Baz, #foo, #Foo]);
+    expect(InitializeTracker.seen, [Baz, 'foo', Foo]);
     runPhase(4);
-    expect(getNames(InitializeTracker.seen), [#Baz, #foo, #Foo, #Bar]);
+    expect(InitializeTracker.seen, [Baz, 'foo', Foo, Bar]);
 
     // Sanity check, future calls should be no-ops
     var originalSize = InitializeTracker.seen.length;
@@ -34,20 +34,16 @@ main() {
   });
 }
 
-Iterable<Symbol> getNames(Iterable<DeclarationMirror> original) =>
-    original.map((d) => d.simpleName);
-
 runPhase(int phase) {
-  run(customFilter: (InstanceMirror meta) =>
-      meta.reflectee is PhasedInitializer &&
-      (meta.reflectee as PhasedInitializer).phase == phase);
+  run(customFilter: (StaticInitializer meta) =>
+      meta is PhasedInitializer && meta.phase == phase);
 }
 
 @PhasedInitializer(3)
 class Foo {}
 
 @PhasedInitializer(2)
-foo() {}
+foo() => 'foo';
 
 @PhasedInitializer(4)
 class Bar {}

--- a/test/static_init_custom_filter_test.dart
+++ b/test/static_init_custom_filter_test.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.static_init_custom_filter_test;
+
+import 'dart:mirrors';
+import 'package:static_init/static_init.dart';
+import 'package:unittest/unittest.dart';
+import 'package:unittest/compact_vm_config.dart';
+import 'initialize_tracker.dart';
+
+main() {
+  useCompactVMConfiguration();
+
+  test('filter option limits which types of annotations will be ran', () {
+    runPhase(1);
+    // Even though Baz extends Bar, only Baz should be run.
+    expect(getNames(InitializeTracker.seen), [#Baz]);
+    runPhase(2);
+    expect(getNames(InitializeTracker.seen), [#Baz, #foo]);
+    runPhase(3);
+    expect(getNames(InitializeTracker.seen), [#Baz, #foo, #Foo]);
+    runPhase(4);
+    expect(getNames(InitializeTracker.seen), [#Baz, #foo, #Foo, #Bar]);
+
+    // Sanity check, future calls should be no-ops
+    var originalSize = InitializeTracker.seen.length;
+    runPhase(1);
+    runPhase(2);
+    runPhase(3);
+    runPhase(4);
+    run();
+    expect(InitializeTracker.seen.length, originalSize);
+  });
+}
+
+Iterable<Symbol> getNames(Iterable<DeclarationMirror> original) =>
+    original.map((d) => d.simpleName);
+
+runPhase(int phase) {
+  run(customFilter: (InstanceMirror meta) =>
+      meta.reflectee is PhasedInitializer &&
+      (meta.reflectee as PhasedInitializer).phase == phase);
+}
+
+@PhasedInitializer(3)
+class Foo {}
+
+@PhasedInitializer(2)
+foo() {}
+
+@PhasedInitializer(4)
+class Bar {}
+
+@PhasedInitializer(1)
+class Baz extends Bar {}
+
+// Static Initializer that has a phase associated with it, this can be used in
+// combination with a custom filter to run intialization in phases.
+class PhasedInitializer extends InitializeTracker {
+  final int phase;
+
+  const PhasedInitializer(this.phase);
+}

--- a/test/static_init_cycle_error_test.dart
+++ b/test/static_init_cycle_error_test.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.static_init_cycle_error_test;
+
+import 'cycle_a.dart';
+import 'package:static_init/static_init.dart';
+import 'package:unittest/unittest.dart';
+import 'package:unittest/compact_vm_config.dart';
+
+main() {
+  useCompactVMConfiguration();
+
+  test('super class cycles are not supported', () {
+    expect(run, throwsUnsupportedError);
+  });
+}

--- a/test/static_init_test.dart
+++ b/test/static_init_test.dart
@@ -4,6 +4,7 @@
 @initializeTracker
 library static_init.static_init_test;
 
+import 'bar.dart';
 import 'foo.dart';
 import 'initialize_tracker.dart';
 import 'package:static_init/static_init.dart';
@@ -16,17 +17,17 @@ main() {
   // Run all static initializers.
   run().then((_) {
     test('annotations are seen in post-order with superclasses first', () {
-      // Foo comes first because its a superclass of Bar.
       var expectedNames = [
-        #static_init.test.bar,
-        Foo,
-        Bar,
-        bar,
         #static_init.test.foo,
-        fooBar,
         foo,
+        fooBar,
+        Foo,
+        #static_init.test.bar,
+        bar,
+        Bar,
         #static_init.static_init_test,
         zap,
+        Zoop, // Zap extends Zoop, so Zoop comes first.
         Zap
       ];
       expect(InitializeTracker.seen, expectedNames);
@@ -43,7 +44,10 @@ main() {
 }
 
 @initializeTracker
-class Zap {}
+class Zoop {}
+
+@initializeTracker
+class Zap extends Zoop {}
 
 @initializeTracker
 zap() {}

--- a/test/static_init_test.dart
+++ b/test/static_init_test.dart
@@ -4,8 +4,8 @@
 @initializeTracker
 library static_init.static_init_test;
 
-import 'bar.dart';
 import 'foo.dart';
+import 'bar.dart';
 import 'initialize_tracker.dart';
 import 'package:static_init/static_init.dart';
 import 'package:unittest/unittest.dart';

--- a/test/static_init_test.dart
+++ b/test/static_init_test.dart
@@ -14,21 +14,24 @@ main() {
   useCompactVMConfiguration();
 
   // Run all static initializers.
-  run();
+  run().then((_) {
 
-  test('annotations are seen in post-order with superclasses first', () {
-    // Foo comes first because its a superclass of Bar.
-    var expectedNames = [#static_init.test.bar, #static_init.test.foo,
-        #static_init.static_init_test, Foo, Bar, 'bar', 'fooBar', 'foo', 'zap',
-        Zap];
-    expect(InitializeTracker.seen, expectedNames);
-  });
+    test('annotations are seen in post-order with superclasses first', () {
+      // Foo comes first because its a superclass of Bar.
+      var expectedNames = [#static_init.test.bar, #static_init.test.foo,
+          #static_init.static_init_test, Foo, Bar, 'bar', 'fooBar', 'foo',
+          'zap', Zap];
+      expect(InitializeTracker.seen, expectedNames);
+    });
 
-  test('annotations only run once', () {
-    // Run the static initializers again, should be a no-op.
-    var originalSize = InitializeTracker.seen.length;
-    run();
-    expect(InitializeTracker.seen.length, originalSize);
+    test('annotations only run once', () {
+      // Run the static initializers again, should be a no-op.
+      var originalSize = InitializeTracker.seen.length;
+      return run().then((_) {
+        expect(InitializeTracker.seen.length, originalSize);
+      });
+    });
+
   });
 }
 

--- a/test/static_init_test.dart
+++ b/test/static_init_test.dart
@@ -4,7 +4,7 @@
 @initializeTracker
 library static_init.static_init_test;
 
-import 'foo.dart'; // For the annotations.
+import 'foo.dart';
 import 'initialize_tracker.dart';
 import 'package:static_init/static_init.dart';
 import 'package:unittest/unittest.dart';
@@ -19,10 +19,9 @@ main() {
   test('annotations are seen in post-order with superclasses first', () {
     // Foo comes first because its a superclass of Bar.
     var expectedNames = [#static_init.test.bar, #static_init.test.foo,
-        #static_init.static_init_test, #Foo, #Bar, #bar, #fooBar, #foo, #zap,
-        #Zap];
-    var actualNames = InitializeTracker.seen.map((d) => d.simpleName);
-    expect(actualNames, expectedNames);
+        #static_init.static_init_test, Foo, Bar, 'bar', 'fooBar', 'foo', 'zap',
+        Zap];
+    expect(InitializeTracker.seen, expectedNames);
   });
 
   test('annotations only run once', () {
@@ -37,4 +36,4 @@ main() {
 class Zap {}
 
 @initializeTracker
-zap() {}
+zap() => 'zap';

--- a/test/static_init_test.dart
+++ b/test/static_init_test.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.static_init_test;
+
+import 'foo.dart'; // For the annotations.
+import 'initialize_tracker.dart';
+import 'package:static_init/static_init.dart';
+import 'package:unittest/unittest.dart';
+import 'package:unittest/compact_vm_config.dart';
+
+main() {
+  useCompactVMConfiguration();
+
+  // Run all static initializers.
+  run();
+
+  test('annotations are seen in post-order with superclasses first', () {
+    // Foo comes first because its a superclass of Bar.
+    var expectedNames = [#Foo, #Bar, #bar, #fooBar, #foo, #zap, #Zap];
+    var actualNames = InitializeTracker.seen.map((d) => d.simpleName);
+    expect(actualNames, expectedNames);
+  });
+
+  test('annotations only run once', () {
+    // Run the static initializers again, should be a no-op.
+    var originalSize = InitializeTracker.seen.length;
+    run();
+    expect(InitializeTracker.seen.length, originalSize);
+  });
+}
+
+@initializeTracker
+class Zap {}
+
+@initializeTracker
+zap() {}

--- a/test/static_init_test.dart
+++ b/test/static_init_test.dart
@@ -1,6 +1,7 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+@initializeTracker
 library static_init.static_init_test;
 
 import 'foo.dart'; // For the annotations.
@@ -17,7 +18,9 @@ main() {
 
   test('annotations are seen in post-order with superclasses first', () {
     // Foo comes first because its a superclass of Bar.
-    var expectedNames = [#Foo, #Bar, #bar, #fooBar, #foo, #zap, #Zap];
+    var expectedNames = [#static_init.test.bar, #static_init.test.foo,
+        #static_init.static_init_test, #Foo, #Bar, #bar, #fooBar, #foo, #zap,
+        #Zap];
     var actualNames = InitializeTracker.seen.map((d) => d.simpleName);
     expect(actualNames, expectedNames);
   });

--- a/test/static_init_test.dart
+++ b/test/static_init_test.dart
@@ -15,12 +15,20 @@ main() {
 
   // Run all static initializers.
   run().then((_) {
-
     test('annotations are seen in post-order with superclasses first', () {
       // Foo comes first because its a superclass of Bar.
-      var expectedNames = [#static_init.test.bar, Foo, Bar, bar,
-          #static_init.test.foo, fooBar, foo, #static_init.static_init_test,
-          zap, Zap];
+      var expectedNames = [
+        #static_init.test.bar,
+        Foo,
+        Bar,
+        bar,
+        #static_init.test.foo,
+        fooBar,
+        foo,
+        #static_init.static_init_test,
+        zap,
+        Zap
+      ];
       expect(InitializeTracker.seen, expectedNames);
     });
 
@@ -31,7 +39,6 @@ main() {
         expect(InitializeTracker.seen.length, originalSize);
       });
     });
-
   });
 }
 

--- a/test/static_init_test.dart
+++ b/test/static_init_test.dart
@@ -18,9 +18,9 @@ main() {
 
     test('annotations are seen in post-order with superclasses first', () {
       // Foo comes first because its a superclass of Bar.
-      var expectedNames = [#static_init.test.bar, #static_init.test.foo,
-          #static_init.static_init_test, Foo, Bar, 'bar', 'fooBar', 'foo',
-          'zap', Zap];
+      var expectedNames = [#static_init.test.bar, Foo, Bar, bar,
+          #static_init.test.foo, fooBar, foo, #static_init.static_init_test,
+          zap, Zap];
       expect(InitializeTracker.seen, expectedNames);
     });
 
@@ -39,4 +39,4 @@ main() {
 class Zap {}
 
 @initializeTracker
-zap() => 'zap';
+zap() {}

--- a/test/static_init_type_filter_test.dart
+++ b/test/static_init_type_filter_test.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+library static_init.static_init_type_filter_test;
+
+import 'dart:mirrors';
+import 'package:static_init/static_init.dart';
+import 'package:unittest/unittest.dart';
+import 'package:unittest/compact_vm_config.dart';
+
+// Initializers will mess with this value, and it gets reset to 0 at the
+// start of every test.
+var total;
+
+main() {
+  useCompactVMConfiguration();
+
+  setUp(() {
+    total = 0;
+  });
+
+  test('filter option limits which types of annotations will be ran', () {
+    run(typeFilter: const [_Adder]);
+    expect(total, 2);
+    run(typeFilter: const [_Subtractor]);
+    expect(total, 0);
+
+    // Sanity check, future calls should be no-ops
+    run(typeFilter: const [_Adder]);
+    expect(total, 0);
+    run(typeFilter: const [_Subtractor]);
+    expect(total, 0);
+  });
+}
+
+@adder
+a() {}
+@subtractor
+b() {}
+@adder
+@subtractor
+c() {}
+
+// Static Initializer that increments `total` by one.
+class _Adder implements StaticInitializer<DeclarationMirror> {
+  const _Adder();
+
+  @override
+  initialize(DeclarationMirror t) => total++;
+}
+const adder = const _Adder();
+
+// Static Initializer that decrements `total` by one.
+class _Subtractor implements StaticInitializer<DeclarationMirror> {
+  const _Subtractor();
+
+  @override
+  initialize(DeclarationMirror t) => total--;
+}
+const subtractor = const _Subtractor();

--- a/test/static_init_type_filter_test.dart
+++ b/test/static_init_type_filter_test.dart
@@ -20,16 +20,16 @@ main() {
   });
 
   test('filter option limits which types of annotations will be ran', () {
-    run(typeFilter: const [_Adder]);
-    expect(total, 2);
-    run(typeFilter: const [_Subtractor]);
-    expect(total, 0);
-
-    // Sanity check, future calls should be no-ops
-    run(typeFilter: const [_Adder]);
-    expect(total, 0);
-    run(typeFilter: const [_Subtractor]);
-    expect(total, 0);
+    return run(typeFilter: const [_Adder]).then((_) {
+      expect(total, 2);
+    }).then((_) => run(typeFilter: const [_Subtractor])).then((_) {
+      expect(total, 0);
+    }).then((_) => run(typeFilter: const [_Adder])).then((_) {
+      // Sanity check, future calls should be no-ops
+      expect(total, 0);
+    }).then((_) => run(typeFilter: const [_Subtractor])).then((_) {
+      expect(total, 0);
+    });
   });
 }
 

--- a/test/static_init_type_filter_test.dart
+++ b/test/static_init_type_filter_test.dart
@@ -42,19 +42,19 @@ b() {}
 c() {}
 
 // Static Initializer that increments `total` by one.
-class _Adder implements StaticInitializer<DeclarationMirror> {
+class _Adder implements StaticInitializer<dynamic> {
   const _Adder();
 
   @override
-  initialize(DeclarationMirror t) => total++;
+  initialize(_) => total++;
 }
 const adder = const _Adder();
 
 // Static Initializer that decrements `total` by one.
-class _Subtractor implements StaticInitializer<DeclarationMirror> {
+class _Subtractor implements StaticInitializer<dynamic> {
   const _Subtractor();
 
   @override
-  initialize(DeclarationMirror t) => total--;
+  initialize(_) => total--;
 }
 const subtractor = const _Subtractor();


### PR DESCRIPTION
This deviates from the design doc somewhat, differences are listed below:
1. Libraries are visited in post-order, but annotations within the libraries are not visited in text-source order. This is because the ClassMirror implementation doesn't implement the location property. The result is that method annotations execute in text-source order but class annotations are mixed in somewhat arbitrarily.
2. There are two optional arguments to `run`, `typeFilter` and `customFilter`, instead of just `filter`. The `typeFilter` is analogous to the `filter` described in the design doc, and `customFilter` accepts a function with this signature `bool (StaticInitializer annotation)`.
