### PR TITLE
Use dart_style to avoid whitespace issues during testing.

### DIFF
--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -10,6 +10,7 @@ import 'package:analyzer/src/generated/element.dart';
 import 'package:barback/barback.dart';
 import 'package:code_transformers/assets.dart';
 import 'package:code_transformers/resolver.dart';
+import 'package:dart_style/dart_style.dart';
 import 'package:glob/glob.dart';
 import 'package:html5lib/dom.dart' as dom;
 import 'package:html5lib/parser.dart' show parse;
@@ -286,13 +287,13 @@ class _BootstrapFileBuilder {
         .forEach((lib, prefix) => _writeImport(lib, prefix, importsBuffer));
 
     // TODO(jakemac): copyright and library declaration
-    return '''
+    return new DartFormatter().format('''
 $importsBuffer
 main() {
 $initializersBuffer
   i0.main();
 }
-''';
+''');
   }
 
   _writeImport(LibraryElement lib, String prefix, StringBuffer buffer) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ homepage: https://github.com/dart-lang/initialize
 dependencies:
   barback: '>=0.14.2 <0.16.0'
   code_transformers: '>=0.2.3 <0.3.0'
+  dart_style: '>=0.1.3 <0.2.0'
   glob: ">=1.0.4 <2.0.0"
   html5lib: '>=0.12.0 <0.13.0'
   path: '>=1.3.0 <2.0.0'

--- a/test/transformer_test.dart
+++ b/test/transformer_test.dart
@@ -4,11 +4,14 @@
 library initialize.transformer_test;
 
 import 'common.dart';
+import 'package:dart_style/dart_style.dart';
 import 'package:initialize/transformer.dart';
 import 'package:unittest/compact_vm_config.dart';
 
 main() {
   useCompactVMConfiguration();
+
+  var formatter = new DartFormatter();
 
   var htmlTransformer = new InitializeTransformer(['web/*.html']);
   var dartTransformer = new InitializeTransformer(['web/index.dart']);
@@ -70,7 +73,7 @@ main() {
           <script type="application/dart" src="index.initialize.dart"></script>
 
         </body></html>'''.replaceAll('        ', ''),
-    'a|web/index.initialize.dart': '''
+    'a|web/index.initialize.dart': formatter.format('''
         import 'package:initialize/src/static_loader.dart';
         import 'package:initialize/initialize.dart';
         import 'index.dart' as i0;
@@ -96,7 +99,7 @@ main() {
 
           i0.main();
         }
-        '''.replaceAll('        ', '')
+        ''')
   }, []);
 
   testPhases('constructor arguments', [[dartTransformer]], {
@@ -129,7 +132,7 @@ main() {
     'initialize|lib/initialize.dart': mockInitialize,
     'test_initializers|lib/common.dart': commonInitializers,
   }, {
-    'a|web/index.initialize.dart': '''
+    'a|web/index.initialize.dart': formatter.format('''
         import 'package:initialize/src/static_loader.dart';
         import 'package:initialize/initialize.dart';
         import 'index.dart' as i0;
@@ -152,6 +155,6 @@ main() {
 
           i0.main();
         }
-        '''.replaceAll('        ', '')
+        ''')
   }, []);
 }


### PR DESCRIPTION
Generate fancily formatted code & no more worries about indentation screwing up the unit tests.